### PR TITLE
WITI-346 - Update the Mega Menu to Follow New UI

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,6 @@
 {
   "admin/mega-menu.navigation.label-group": "Mega Menu",
-  "store/mega-menu.submenu.seeAllButton.title": "See all",
+  "store/mega-menu.submenu.seeAllButton.title": "All",
   "store/mega-menu.goBackButton.title": "Go back",
   "admin/mega-menu.tabs.first": "First Level",
   "admin/mega-menu.tabs.second": "Second Level",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,6 +1,6 @@
 {
   "admin/mega-menu.navigation.label-group": "Mega Menú",
-  "store/mega-menu.submenu.seeAllButton.title": "Ver todo",
+  "store/mega-menu.submenu.seeAllButton.title": "Todos",
   "store/mega-menu.goBackButton.title": "Volver",
   "admin/mega-menu.tabs.first": "Primer nivel",
   "admin/mega-menu.tabs.second": "Segundo nivel",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,6 @@
 {
   "admin/mega-menu.navigation.label-group": "Mega Menu",
-  "store/mega-menu.submenu.seeAllButton.title": "Ver tudo",
+  "store/mega-menu.submenu.seeAllButton.title": "Tudo",
   "store/mega-menu.goBackButton.title": "volte",
   "admin/mega-menu.tabs.first": "Primeiro nível",
   "admin/mega-menu.tabs.second": "Segundo nível",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1365,7 +1365,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/ConfigMenuContainer.tsx
+++ b/react/ConfigMenuContainer.tsx
@@ -9,7 +9,8 @@ import { formatIOMessage } from 'vtex.native-types'
 
 import FirsLevelContainer from './Category/FirstLevelContainer'
 import SecondLevelContainer from './Category/SecondLevelContainer'
-import ThirdLevelContainer from './Category/ThirdLevelContainer'
+//! WITI-346 - removed third level per client request, but keeping code for future use
+// import ThirdLevelContainer from './Category/ThirdLevelContainer'
 import CategoryContainer from './Category/CategoryContainer'
 import GET_MENUS from './graphql/queries/getMenus.graphql'
 import { DataMenuProvider } from './shared'
@@ -151,7 +152,9 @@ const ConfigMenuContainer: FC<InjectedIntlProps> = ({ intl }) => {
             >
               <SecondLevelContainer />
             </Tab>
-            <Tab
+            {/* WITI-346 - removed third level per client request, but keeping
+            code for future use */}
+            {/* <Tab
               label={formatIOMessage({ id: messages.thirdLevelTab.id, intl })}
               active={currentTab === 3}
               onClick={() => {
@@ -160,7 +163,7 @@ const ConfigMenuContainer: FC<InjectedIntlProps> = ({ intl }) => {
               }}
             >
               <ThirdLevelContainer />
-            </Tab>
+            </Tab> */}
           </Tabs>
         </Layout>
       </DataMenuProvider>

--- a/react/MegaMenu/components/HorizontalMenu.tsx
+++ b/react/MegaMenu/components/HorizontalMenu.tsx
@@ -102,7 +102,10 @@ const HorizontalMenu: FC<InjectedIntlProps> = observer(({ intl }) => {
                 to={d.slug}
                 iconId={d.icon}
                 accordion={hasCategories}
-                className={classNames('pv3 mh5', d.id === departmentActive?.id && 'vtex-active-menu-link')}
+                className={classNames(
+                  'pv3 mh5',
+                  d.id === departmentActive?.id && 'vtex-active-menu-link'
+                )}
                 style={d.styles}
                 enableStyle={d.enableSty}
                 closeMenu={openMenu}
@@ -145,7 +148,7 @@ const HorizontalMenu: FC<InjectedIntlProps> = observer(({ intl }) => {
           'list ma0 pa0 pb3 br b--muted-4'
         )}
       >
-        <h3 className="f4 fw7 c-on-base lh-copy ma0 pv5 ph5 vtex-mege-menu-header">
+        <h3 className="f5 fw7 c-on-base lh-copy ma0 pv5 ph5 vtex-mege-menu-header">
           {formatIOMessage({ id: title, intl })}
         </h3>
         {departments.length ? (

--- a/react/MegaMenu/components/Item.tsx
+++ b/react/MegaMenu/components/Item.tsx
@@ -107,11 +107,12 @@ const Item: FC<ItemProps> = observer((props) => {
     <div
       className={classNames(handles.styledLinkContent, 'flex justify-between')}
     >
-      
       <div
         className={classNames(
           handles.styledLinkText,
-          `flex justify-between items-center ${departmentActive ? 'vtex-active-link' : null}`,
+          `flex justify-between items-center f7 ${
+            departmentActive ? 'vtex-active-link' : null
+          }`,
           iconPosition === 'left' && iconComponent && 'nowrap'
         )}
         {...(enableStyle && { style: stylesItem })}

--- a/react/MegaMenu/components/Submenu.tsx
+++ b/react/MegaMenu/components/Submenu.tsx
@@ -9,8 +9,10 @@ import { applyModifiers, useCssHandles } from 'vtex.css-handles'
 import { formatIOMessage } from 'vtex.native-types'
 import { ExtensionPoint, Link } from 'vtex.render-runtime'
 import { Collapsible } from 'vtex.styleguide'
+import { IconCaret } from 'vtex.store-icons'
 
-import type { MenuItem } from '../../shared'
+//! WITI-346 - removed third level per client request, but keeping code for future use
+// import type { MenuItem } from '../../shared'
 import { megaMenuState } from '../State'
 import styles from '../styles.css'
 import Item from './Item'
@@ -50,7 +52,12 @@ const Submenu: FC<ItemProps> = observer((props) => {
   >({})
 
   const [showBtnCat, setShowBtnCat] = useState(false)
-  const seeAllLink = (to: string, level = 1, className?: string) => (
+  const seeAllLink = (
+    to: string,
+    level = 1,
+    className?: string,
+    departmentName?: string
+  ) => (
     <div
       className={classNames(
         handles.seeAllLinkContainer,
@@ -63,17 +70,25 @@ const Submenu: FC<ItemProps> = observer((props) => {
         to={to}
         className={classNames(
           handles.seeAllLink,
-          'link underline fw7 c-on-base'
+          styles.seeAllLink,
+          'link no-underline fw6 f6 flex items-center'
         )}
         onClick={() => {
           if (closeMenu) closeMenu(false)
         }}
       >
-        {formatIOMessage({ id: messages.seeAllTitle.id, intl })}
+        {formatIOMessage({ id: messages.seeAllTitle.id, intl })}{' '}
+        {departmentName} <IconCaret orientation="right" size={14} />
       </Link>
     </div>
   )
-  const seeAllLinkMobile = (to: string, level = 1, className?: string, name?: string) => (
+
+  const seeAllLinkMobile = (
+    to: string,
+    level = 1,
+    className?: string,
+    name?: string
+  ) => (
     <div
       className={classNames(
         handles.seeAllLinkContainer,
@@ -97,24 +112,25 @@ const Submenu: FC<ItemProps> = observer((props) => {
     </div>
   )
 
-  const subCategories = (items: MenuItem[]) => {
-    return items
-      .filter((v) => v.display)
-      .map((x) => (
-        <div key={x.id} className={classNames(handles.submenuItem, 'mt3')}>
-          <Item
-            to={x.slug}
-            iconId={x.icon}
-            level={3}
-            style={x.styles}
-            enableStyle={x.enableSty}
-            closeMenu={closeMenu}
-          >
-            {x.name}
-          </Item>
-        </div>
-      ))
-  }
+  //! WITI-346 - removed third level per client request, but keeping code for future use
+  // const subCategories = (items: MenuItem[]) => {
+  //   return items
+  //     .filter((v) => v.display)
+  //     .map((x) => (
+  //       <div key={x.id} className={classNames(handles.submenuItem, 'mt3')}>
+  //         <Item
+  //           to={x.slug}
+  //           iconId={x.icon}
+  //           level={3}
+  //           style={x.styles}
+  //           enableStyle={x.enableSty}
+  //           closeMenu={closeMenu}
+  //         >
+  //           {x.name}
+  //         </Item>
+  //       </div>
+  //     ))
+  // }
 
   const items = useMemo(
     () => {
@@ -135,9 +151,11 @@ const Submenu: FC<ItemProps> = observer((props) => {
       return categories
         .filter((j) => j.display)
         .map((category, i) => {
-          const subcategories = category.menu?.length
-            ? subCategories(category.menu)
-            : []
+          const subcategories = []
+          //! WITI-346 - removed third level per client request, but keeping code for future use
+          // const subcategories = category.menu?.length
+          //   ? subCategories(category.menu)
+          //   : []
 
           return (
             <div
@@ -191,11 +209,14 @@ const Submenu: FC<ItemProps> = observer((props) => {
                   }
                   align="right"
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  onClick={subcategories.length > 1 ? (e: any) =>
-                    setCollapsibleStates({
-                      ...collapsibleStates,
-                      [category.id]: e.target.isOpen,
-                    }) : null
+                  onClick={
+                    subcategories.length > 1
+                      ? (e: any) =>
+                          setCollapsibleStates({
+                            ...collapsibleStates,
+                            [category.id]: e.target.isOpen,
+                          })
+                      : null
                   }
                   isOpen={collapsibleStates[category.id]}
                   caretColor={`${
@@ -222,7 +243,7 @@ const Submenu: FC<ItemProps> = observer((props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [departmentActive, collapsibleStates]
   )
-  
+
   return (
     <>
       {departmentActive && (
@@ -236,10 +257,21 @@ const Submenu: FC<ItemProps> = observer((props) => {
             )}
           >
             {orientation === 'horizontal' && showBtnCat ? (
-              seeAllLink(departmentActive.slug, 1, 't-small ml7')
+              seeAllLink(
+                departmentActive.slug,
+                1,
+                't-small ml7',
+                departmentActive.name
+              )
             ) : (
               <>
-                {departmentActive && seeAllLinkMobile(departmentActive.slug, 1, 't-small ml7', departmentActive.name)} 
+                {departmentActive &&
+                  seeAllLinkMobile(
+                    departmentActive.slug,
+                    1,
+                    't-small ml7',
+                    departmentActive.name
+                  )}
                 <div />
               </>
             )}
@@ -257,9 +289,7 @@ const Submenu: FC<ItemProps> = observer((props) => {
                 <ExtensionPoint id="after-menu" />
               </>
             ) : (
-              <>
-                {items}
-              </>
+              <>{items}</>
             )}
           </div>
         </>

--- a/react/MegaMenu/styles.css
+++ b/react/MegaMenu/styles.css
@@ -10,12 +10,12 @@
 
 .submenuList {
   display: grid;
-  gap: 2rem;
+  gap: 1rem;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 }
 
 .submenuList > .submenuItem {
-  max-width: 200px;
+  max-width: 240px;
 }
 
 .styledLink,
@@ -31,4 +31,15 @@
   color: var(--text-white);
   font-size: 12px;
   font-family: 'Poppins';
+}
+
+.seeAllLink {
+  color: var(--star-blue);
+  font-family: 'Poppins';
+}
+
+.seeAllLink > svg {
+  stroke: white;
+  stroke-width: 1px;
+  margin-left: 8px;
 }

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@vtex/tsconfig",
   "compilerOptions": {
+    "jsx": "react",
     "noEmitOnError": false,
     "lib": ["dom"],
     "module": "esnext",


### PR DESCRIPTION
**What problem is this solving?**
[
Ticket](https://syatt.atlassian.net/browse/WITI-346)

Updated the Mega Menu to Follow [New UI](https://syattprojects.invisionapp.com/console/share/UC2S7BZMPN/964951299/inspect),

Commented out third level UI, in case William will want it back.

**Screenshots or example usage:**

https://witi346--whitebird.myvtex.com/seasonal
https://witi346--whitebird.myvtex.com/admin/mega-menu/1/

![Screen Shot 2022-11-22 at 09 09 43](https://user-images.githubusercontent.com/44775362/203355715-129a1cce-55a0-4991-b866-fc75b057b932.png)

![Screen Shot 2022-11-22 at 10 34 24](https://user-images.githubusercontent.com/44775362/203355706-54791e79-e8e6-4d66-b92e-5b3e885d8e65.png)

