### PR TITLE
Release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,9 @@
 
 ## [Unreleased]
 
-## [3.0.1] - 2022-05-12
+## [3.1.0] - 2022-11-28
 
-## [2.7.0] - 2022-04-01
-
-## [2.6.0] - 2022-04-01
-
-## [2.4.2] - 2022-02-01
-
-## [2.4.0] - 2022-01-25
-
-## [2.3.0] - 2022-01-19
+- WITI-346 - Updated the app to have a max of 2 levels. Commented out 3rd level logic for now.
 
 ### Added
 - Added link to category 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "mega-menu",
   "vendor": "syatt",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "title": "Mega Menu",
   "description": "Create, personalize and manage the category tree. It's can be used in the shop as main menu",
   "mustUpdateAt": "2022-08-28",
@@ -29,9 +29,7 @@
     "support": {
       "url": "https://support.vtex.com/hc/requests"
     },
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "policies": [
     {


### PR DESCRIPTION
## [3.1.0] - 2022-11-28

- WITI-346 - Updated the app to have a max of 2 levels. Commented out 3rd level logic for now.
