### PR TITLE
adjustment to menu link padding

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,9 @@
     "support": {
       "url": "https://support.vtex.com/hc/requests"
     },
-    "availableCountries": ["*"]
+    "availableCountries": [
+      "*"
+    ]
   },
   "policies": [
     {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1365,7 +1365,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/MegaMenu/components/HorizontalMenu.tsx
+++ b/react/MegaMenu/components/HorizontalMenu.tsx
@@ -105,7 +105,7 @@ const HorizontalMenu: FC<InjectedIntlProps> = observer(() => {
                 iconId={d.icon}
                 accordion={hasCategories}
                 className={classNames(
-                  'pv5 mh5',
+                  'pv3 mh5',
                   d.id === departmentActive?.id && 'vtex-active-menu-link'
                 )}
                 style={d.styles}

--- a/react/MegaMenu/styles.css
+++ b/react/MegaMenu/styles.css
@@ -1,8 +1,6 @@
 .menuContainer,
 .submenuContainer {
   max-height: calc(75vh - 100px);
-  overflow-x: hidden;
-  overflow-y: scroll;
 }
 
 .menuContainerNav {


### PR DESCRIPTION
## What problem is this solving?
Decreased the padding on menu items in dropdown

<!--- What is the motivation and context for this change? -->
Menu Items were too high and causing a scroll

## How should this be manually tested?
Open mega menu and check if scroll exists

## Screenshots or example usage:

![Screen Shot 2023-01-18 at 4 06 35 PM](https://user-images.githubusercontent.com/85588955/213294701-e792235f-cedf-40b9-8264-e49f7cce3b3a.png)
