### PR TITLE
WITI-532 - changed link color from secondary to primary

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.13",
+    "@vtex/api": "6.45.15",
     "tslint": "^5.12.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.9.7",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -152,10 +152,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.45.13":
-  version "6.45.13"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.13.tgz#836c392fa9567009e34559f08698f6efc95e88cc"
-  integrity sha512-P22/ObNdsgLvagetcDrovFfSXHe8Jb4yHud4U0rXHfIYEIMSnEdQ/QHujF3CEa5AiZnvbR/5W5ynGtWHYHOv9A==
+"@vtex/api@6.45.15":
+  version "6.45.15"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.15.tgz#aa987d22f7df16ce2861130deda6ffd63156817b"
+  integrity sha512-Rg1VGDzJ4hHUNp1vSidMdGGPojr1PikMTptlZsJ3oNZVdEo4cPx2l8ZcAEwHWORL7QjPjXaEgmeA5ZOSf+boCQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1365,7 +1365,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/MegaMenu/styles.css
+++ b/react/MegaMenu/styles.css
@@ -37,7 +37,7 @@
 }
 
 .seeAllLink {
-  color: var(--star-blue-secondary);
+  color: var(--star-blue);
   font-family: 'Poppins';
 }
 
@@ -89,5 +89,5 @@
 }
 
 .item-link a {
-  color: var(--star-blue-secondary);
+  color: var(--star-blue);
 }


### PR DESCRIPTION
**What problem is this solving?**
Changed the text/link color to the navy blue

**How should this be manually tested?**
Open the mega menu and the text link should look navy blue
[WITI-532](https://witi532--whitebird.myvtex.com/)

**Screenshots or example usage:**
![Screen Shot 2023-03-13 at 1 41 19 PM](https://user-images.githubusercontent.com/85588955/224783779-82643a8f-6b27-4300-a3de-b574940578be.png)


[WITI-532]: https://syatt.atlassian.net/browse/WITI-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ