### PR TITLE
WITI-608 Fix mega menu overflow

### DIFF
--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1365,7 +1365,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/MegaMenu/styles.css
+++ b/react/MegaMenu/styles.css
@@ -1,8 +1,3 @@
-.menuContainer,
-.submenuContainer {
-  max-height: calc(75vh - 100px);
-}
-
 .menuContainerNav {
   box-shadow: 0 2px 24px 0 rgba(0, 0, 0, 0.13);
 }


### PR DESCRIPTION
**What problem is this solving?**

If the screen isn't tall enough the first nav level items will over flow the container. We should make the container bigger and/or use a scrollbar to avoid this.

Issue created in Slack from a [message](https://syatt.slack.com/archives/C022C9L92QN/p1680117446115779).

**How should this be manually tested?**

https://witi608--whitebird.myvtex.com/

**Ticket**

https://syatt.atlassian.net/browse/WITI-608